### PR TITLE
added support for linux arm64

### DIFF
--- a/ElectronSharp.CLI/Commands/Actions/GetTargetPlatformInformation.cs
+++ b/ElectronSharp.CLI/Commands/Actions/GetTargetPlatformInformation.cs
@@ -39,6 +39,10 @@ namespace ElectronSharp.CLI.Commands.Actions
                     netCorePublishRid      = "linux-arm";
                     electronPackerPlatform = "linux";
                     break;
+                case "linux-arm64":
+                    netCorePublishRid = "linux-arm64";
+                    electronPackerPlatform = "linux";
+                    break;
                 case "custom":
                     var splittedSpecified = specifiedPlatfromFromCustom.Split(';');
                     netCorePublishRid      = splittedSpecified[0];
@@ -75,8 +79,25 @@ namespace ElectronSharp.CLI.Commands.Actions
                     }
                     else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                     {
-                        netCorePublishRid      = "linux-x64";
-                        electronPackerPlatform = "linux";
+                        if (RuntimeInformation.OSArchitecture.Equals(Architecture.Arm64))
+                        {
+                            //ARM64 device - e.g. Raspberry Pi
+                            netCorePublishRid = "linux-arm64";
+                            electronPackerPlatform = "linux";
+                        }
+                        else if (RuntimeInformation.OSArchitecture.Equals(Architecture.Arm))
+                        {
+                            //ARM device - e.g. Raspberry Pi 2 or 2
+                            netCorePublishRid = "linux-arm";
+                            electronPackerPlatform = "linux";
+                        }
+                        else
+                        {
+                            //Intel Mac:
+                            netCorePublishRid = "linux-x64";
+                            electronPackerPlatform = "linux";
+                        }
+
                     }
 
                     break;

--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ The end result should be an electron app under your __/bin/desktop__ folder.
 ### Note
 > macOS builds can't be created on Windows machines because they require symlinks that aren't supported on Windows (per [this Electron issue](https://github.com/electron-userland/electron-packager/issues/71)). macOS builds can be produced on either Linux or macOS machines.
 
+## Develop
+
+### Install dotnet tool locally
+
+- Build the CLI tool using `dotnet build`, this should create a nuget package in the artifact directory
+- Execute in the main electronnet solution folder
+
+```
+dotnet tool update --add-source ./artifacts/ -g electronsharp.cli -v d	
+```
+
 ## 👨‍💻 Original ([Electron.NET](https://github.com/ElectronSharp/Electron.NET)) Authors 
 
 * **Gregor Biswanger** - (Microsoft MVP, Intel Black Belt and Intel Software Innovator) is a freelance lecturer, consultant, trainer, author and speaker. He is a consultant for large and medium-sized companies, organizations and agencies for software architecture, web- and cross-platform development. You can find Gregor often on the road attending or speaking at international conferences. - [Cross-Platform-Blog](http://www.cross-platform-blog.com) - Twitter [@BFreakout](https://www.twitter.com/BFreakout)  


### PR DESCRIPTION
On any modern arm box (opi, bpi, rpi) - the optimal architecture is by default arm64 which is not supported by the build tool. This simple PR adds proper detection so that the build tool selects `linux-arm64` instead of `linux-x64`