### PR TITLE
Update README.md to use correct build command on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ A complete documentation will follow. Until then take a look in the source code 
 Here you need the ElectronSharp CLI as well. Type the following command in your ASP.NET Core folder:
 
 ```
-electronize build /target win
+electron-sharp build /target win
 ```
 
 There are additional platforms available:


### PR DESCRIPTION
README.md still refers to `electronize build` for building an application for release on Windows. I accidently copied this command and was unable to build an exe that runs correctly.

- Updated README.md to remove old `electronize build` and use `electron-sharp build` instead.