### PR TITLE
Add ability to set switch value in manifest cliFlags property

### DIFF
--- a/ElectronSharp.Host/main.js
+++ b/ElectronSharp.Host/main.js
@@ -161,7 +161,17 @@ if (manifestJsonFile.singleInstance || manifestJsonFile.aspCoreBackendPort != 'r
 //Some flags need to be set before app is ready
 if (manifestJsonFile.hasOwnProperty('cliFlags') && manifestJsonFile.cliFlags.length > 0) {
     manifestJsonFile.cliFlags.forEach(flag => {
-        app.commandLine.appendSwitch(flag);
+       if (typeof flag !== 'string') return;
+
+        // Split on the first '=' if present
+        const [switchName, ...rest] = flag.split('=');
+        const switchValue = rest.length > 0 ? rest.join('=') : undefined;
+    
+        if (switchValue !== undefined) {
+            app.commandLine.appendSwitch(switchName, switchValue);
+        } else {
+            app.commandLine.appendSwitch(switchName);
+        }
     });
 }
 


### PR DESCRIPTION
`main.js` adds command line switches to the spawned electron process if "cliFlags" property has values in `electron.manifest.json`, but it does not allow setting a value for the switch. This change splits each item in the cliFlags array on the first '=' and sets the switch value, if provided.

This came up due to the new Electron 36 [breaking change](https://www.electronjs.org/docs/latest/breaking-changes#changed-gtk-4-is-default-when-running-gnome) on Linux when running GNOME and attempting to apply [the fix](https://github.com/electron/electron/issues/46538#issuecomment-2808806722).