### PR TITLE
Fixing an issue with incorrect tag in  .cshtml files

### DIFF
--- a/ElectronSharp.SampleApp/Properties/launchSettings.json
+++ b/ElectronSharp.SampleApp/Properties/launchSettings.json
@@ -11,7 +11,7 @@
     },
     "run with electronize": {
       "commandName": "Executable",
-      "executablePath": "$(SolutionDir)ElectronSharp.CLI\\bin\\Debug\\net7.0\\dotnet-electron-sharp.exe",
+      "executablePath": "$(SolutionDir)ElectronSharp.CLI\\bin\\Debug\\net9.0\\dotnet-electron-sharp.exe",
       "commandLineArgs": "start /from-build-output $(SolutionDir)ElectronSharp.SampleApp\\bin\\$(Configuration)\\net9.0",
       "workingDirectory": "$(SolutionDir)ElectronSharp.SampleApp"
     },

--- a/ElectronSharp.SampleApp/Views/About/Index.cshtml
+++ b/ElectronSharp.SampleApp/Views/About/Index.cshtml
@@ -20,7 +20,7 @@
 {
     return WebHost.CreateDefaultBuilder(args)
         .UseElectron(args)
-        .UseStartup<Startup>()
+        .UseStartup&lt;Startup>()
         .Build();
 }</code>
                     </pre>

--- a/ElectronSharp.SampleApp/Views/HostHook/Index.cshtml
+++ b/ElectronSharp.SampleApp/Views/HostHook/Index.cshtml
@@ -44,7 +44,7 @@
     };
     var folderPath = await Electron.Dialog.ShowOpenDialogAsync(mainWindow, options);
 
-    var resultFromTypeScript = await Electron.HostHook.CallAsync<string>("create-excel-file", folderPath);
+    var resultFromTypeScript = await Electron.HostHook.CallAsync&lt;string>("create-excel-file", folderPath);
     Electron.IpcMain.Send(mainWindow, "excel-file-created", resultFromTypeScript);
 });</code>
                     </pre>


### PR DESCRIPTION
- ##### Fixed an issue with incorrect < tag inside code samples. This results in code not displaying correctly in SampleApp

##### Before 

<img width="1152" height="940" alt="image" src="https://github.com/user-attachments/assets/a9f052b8-1611-4169-83b2-562fb2257f0e" />

##### After

<img width="1152" height="940" alt="image" src="https://github.com/user-attachments/assets/94b0a9d4-b098-4cd6-b027-f4f4c377ea1c" />

<br/>   

- ##### Fixed an issue in launchSettings.json pointing to incorrect version of dotnet. https://github.com/theolivenbaum/electron-sharp/blob/e2e6df8b88e500c60b7a3ea97343e8da77ed2744/ElectronSharp.SampleApp/Properties/launchSettings.json#L14 
