### PR TITLE
Upgrade Electron to 42.3.0 and add CLAUDE.md guidance

### DIFF
--- a/.devops/build-nuget.yaml
+++ b/.devops/build-nuget.yaml
@@ -1,5 +1,5 @@
 variables:
-  PackageVersion: 40.0.0.$(Build.BuildId)
+  PackageVersion: 42.3.0.$(Build.BuildId)
   projectAPI:  './ElectronSharp.API/ElectronSharp.API.csproj'
   projectCLI:  './ElectronSharp.CLI/ElectronSharp.CLI.csproj'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repository.
+
+## What this is
+
+**ElectronSharp** is a hard fork of Electron.NET, maintained by @theolivenbaum and used to build the Curiosity app. It lets you build cross-platform desktop apps with .NET 10 + ASP.NET Core (Razor Pages, MVC, Blazor) by wrapping a Node/Electron host and bridging to it over a Socket.IO IPC channel.
+
+- Public README: `README.md`
+- Repo: https://github.com/theolivenbaum/electron-sharp
+- Published NuGet packages: `ElectronSharp.API`, `ElectronSharp.CLI`
+
+## Solution layout
+
+| Project | Role |
+|---|---|
+| `ElectronSharp.API` | The .NET API surface (`Electron.*` static class, IPC client). Published as NuGet `ElectronSharp.API`. TFM `net10.0`. |
+| `ElectronSharp.CLI` | `dotnet tool` named **`electron-sharp`**. Commands: `start`, `build`, `init`, `add`, `version`. Commands live in `ElectronSharp.CLI/Commands/`. The CLI ships the Host as embedded resources (see `EmbeddedFileHelper.cs`) and extracts them into the consumer project's `obj/Host/` at build time. |
+| `ElectronSharp.Host` | The Electron-side Node.js app: `main.js` plus `api/*.js` modules. Talks to the .NET process over Socket.IO. **This is what gets embedded into the CLI package.** |
+| `ElectronSharp.SampleApp` | Example ASP.NET Core app demonstrating usage. Not published. |
+| `ElectronSharp.API.Tests` | xUnit tests. |
+| `Releaser` | Maintainer-only console app for bumping the pinned Electron version. Run as `cd Releaser && dotnet run <x.y.z>`. |
+
+## Where the Electron version is pinned
+
+Three places, kept in sync by the `Releaser` project. Always use `Releaser` (or update all three) when bumping:
+
+1. `ElectronSharp.Host/package.json` — `devDependencies.electron`
+2. `ElectronSharp.CLI/Commands/BuildCommand.cs` — `_defaultElectronVersion` constant
+3. `.devops/build-nuget.yaml` — `PackageVersion` variable (the NuGet package version is `<electron-version>.$(Build.BuildId)`, mirroring the Electron version)
+
+`Releaser/Program.cs` uses three regexes that **require `x.x.x` form (1–2 digits per component)**. If you change the format, update the regexes too.
+
+After updating, `Releaser` also runs `npm update -D` in `ElectronSharp.Host/`.
+
+## Host (Node side)
+
+- Entry: `ElectronSharp.Host/main.js`. Sets up the Electron app, spawns the ASP.NET Core executable, starts a Socket.IO server, authenticates the .NET client, and registers handlers from `api/*.js`.
+- API modules in `ElectronSharp.Host/api/` mirror the Electron APIs the .NET wrapper exposes (app, browserWindows, dialog, menu, ipc, notification, tray, autoUpdater, etc.).
+- Dependencies of note: `electron`, `electron-updater`, `socket.io`, `@electron/notarize`, `portscanner`, `image-size`.
+- HostHook extensibility point: `ElectronSharp.Host/ElectronHostHook/` — consumer apps drop TypeScript in here to extend the host.
+- Splash screen: `ElectronSharp.Host/splashscreen/`.
+
+## CLI (build pipeline)
+
+`ElectronSharp.CLI/Commands/BuildCommand.cs` orchestrates `dotnet publish` + `electron-builder`/`electron-packager`. Notable params: `/target`, `/electron-arch`, `/electron-version`, `/package-json`, `/install-modules`, `/Version`, `/p:Property=...`.
+
+Embedded Host files are declared in `ElectronSharp.CLI/ElectronSharp.CLI.csproj` (lines ~43–72). Adding a new file to `ElectronSharp.Host/` means adding an `<EmbeddedResource>` entry, otherwise consumers won't see it.
+
+## Build / test / pack
+
+Local:
+
+```bash
+# Restore + build
+dotnet build ElectronSharp.sln -c Release
+
+# Test
+dotnet test ElectronSharp.API.Tests/ElectronSharp.API.Tests.csproj
+
+# Pack (output to ./artifacts)
+dotnet pack ElectronSharp.API/ElectronSharp.API.csproj -c Release
+dotnet pack ElectronSharp.CLI/ElectronSharp.CLI.csproj -c Release
+
+# Install the locally built CLI tool
+dotnet tool update --add-source ./artifacts/ -g electronsharp.cli
+```
+
+CI: `.devops/build-nuget.yaml` (Azure Pipelines). Builds with the .NET 9 SDK (currently — it still produces net10 output via SDK rolling-forward), packs, and pushes to the `nuget-curiosity-org` feed. The `PackageVersion` is sourced from the YAML, not from the csproj.
+
+## TFMs and versions
+
+- All projects: `net10.0`.
+- NuGet csproj `<Version>` is `99.0.0.0` locally (a sentinel); the real version is injected by CI via `/property:Version=$(PackageVersion)`.
+
+## Conventions
+
+- C#: file-scoped or block namespaces under `ElectronSharp.*`; static `Electron` class is the public entry point; commands implement `ICommand` and are dispatched from `Program.cs`.
+- No root `.editorconfig`. `.gitattributes` only sets line-ending normalization.
+- TypeScript in `ElectronSharp.Host`: target ES2020, module commonjs. ESLint configured.
+- No emojis in code or commits.
+
+## Branch and commit etiquette
+
+- This workspace operates on the branch declared in the system prompt — develop, commit, and push there.
+- Don't open PRs unless asked.
+- Don't include the model identifier in commits, PR text, or code.
+
+## Common gotchas
+
+- **Adding a new Host file?** Add it as an `<EmbeddedResource>` in `ElectronSharp.CLI.csproj` *and* make sure `EmbeddedFileHelper` extracts it (it iterates known files).
+- **Bumping Electron?** Use `Releaser`. Don't hand-edit the three pinned locations or they drift.
+- **Bumping electron-updater or other Host deps?** Edit `ElectronSharp.Host/package.json` and run `npm install` in that directory to refresh the lockfile — but the repo doesn't currently commit a lockfile, so consumers' `npm install` resolves at build time.
+- **The .NET API and Host JS are tightly coupled.** When you change a Socket.IO message name on one side, change it on the other. Search both `ElectronSharp.API/` and `ElectronSharp.Host/api/` for the channel name.

--- a/ElectronSharp.API/Entities/CookieChangedCause.cs
+++ b/ElectronSharp.API/Entities/CookieChangedCause.cs
@@ -35,6 +35,23 @@ namespace ElectronSharp.API.Entities
         ///   The cookie was overwritten with an already-expired expiration date.
         /// </summary>
         [JsonProperty("expired_overwrite")]
-        expiredOverwrite
+        expiredOverwrite,
+
+        /// <summary>
+        /// The cookie was inserted. Emitted when a new cookie is set (Electron 41+).
+        /// </summary>
+        inserted,
+
+        /// <summary>
+        /// An identical cookie was set, resulting in no change (Electron 41+).
+        /// </summary>
+        [JsonProperty("inserted-no-change-overwrite")]
+        insertedNoChangeOverwrite,
+
+        /// <summary>
+        /// Only cookie attributes were updated; the value is unchanged (Electron 41+).
+        /// </summary>
+        [JsonProperty("inserted-no-value-change-overwrite")]
+        insertedNoValueChangeOverwrite
     }
 }

--- a/ElectronSharp.CLI/Commands/BuildCommand.cs
+++ b/ElectronSharp.CLI/Commands/BuildCommand.cs
@@ -10,7 +10,7 @@ namespace ElectronSharp.CLI.Commands
 {
     public class BuildCommand : ICommand
     {
-        private const string _defaultElectronVersion = "40.0.0";
+        private const string _defaultElectronVersion = "42.3.0";
 
         public const string COMMAND_NAME        = "build";
         public const string COMMAND_DESCRIPTION = "Build your Electron Application.";

--- a/ElectronSharp.CLI/ElectronSharp.CLI.csproj
+++ b/ElectronSharp.CLI/ElectronSharp.CLI.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>dotnet-electron-sharp</AssemblyName>
     <ToolCommandName>electron-sharp</ToolCommandName>
-    <PackageType>DotnetCliTool</PackageType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>..\artifacts</PackageOutputPath>
     <PackageId>ElectronSharp.CLI</PackageId>

--- a/ElectronSharp.Host/package-lock.json
+++ b/ElectronSharp.Host/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "dasherize": "^2.0.0",
-                "electron-updater": "^6.3.0-alpha.4",
+                "electron-updater": "^6.8.6",
                 "image-size": "^1.1.1",
                 "portscanner": "^2.2.0",
                 "socket.io": "^4.7.5"
@@ -21,76 +21,30 @@
                 "@typescript-eslint/eslint-plugin": "^7.8.0",
                 "@typescript-eslint/parser": "^7.8.0",
                 "dotenv": "^16.4.5",
-                "electron": "40.0.0",
+                "electron": "42.3.0",
                 "eslint": "^8.57.0",
                 "typescript": "^5.4.5"
             }
         },
         "node_modules/@electron/get": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-            "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+            "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.1.1",
-                "env-paths": "^2.2.0",
-                "fs-extra": "^8.1.0",
-                "got": "^11.8.5",
+                "env-paths": "^3.0.0",
+                "graceful-fs": "^4.2.11",
                 "progress": "^2.0.3",
-                "semver": "^6.2.0",
+                "semver": "^7.6.3",
                 "sumchecker": "^3.0.1"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=22.12.0"
             },
             "optionalDependencies": {
-                "global-agent": "^3.0.0"
-            }
-        },
-        "node_modules/@electron/get/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/@electron/get/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "dev": true,
-            "license": "MIT",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/@electron/get/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@electron/get/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4.0.0"
+                "undici": "^7.24.4"
             }
         },
         "node_modules/@electron/notarize": {
@@ -162,9 +116,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -173,9 +127,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -212,9 +166,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -223,9 +177,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -295,50 +249,11 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@sindresorhus/is": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
-        },
         "node_modules/@socket.io/component-emitter": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
             "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
             "license": "MIT"
-        },
-        "node_modules/@szmarczak/http-timer": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-            "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "defer-to-connect": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@types/cacheable-request": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-            "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-cache-semantics": "*",
-                "@types/keyv": "^3.1.4",
-                "@types/node": "*",
-                "@types/responselike": "^1.0.0"
-            }
         },
         "node_modules/@types/cors": {
             "version": "2.8.19",
@@ -349,37 +264,19 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/keyv": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-            "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/node": {
-            "version": "20.19.30",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-            "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+            "version": "20.19.41",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+            "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
         },
-        "node_modules/@types/responselike": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-            "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-            "dev": true,
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -590,9 +487,9 @@
             }
         },
         "node_modules/@ungap/structured-clone": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-            "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+            "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -610,9 +507,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -633,9 +530,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -726,19 +623,10 @@
                 "node": "^4.5.0 || >= 5.9"
             }
         },
-        "node_modules/boolean": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-            "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -769,9 +657,9 @@
             }
         },
         "node_modules/builder-util-runtime": {
-            "version": "9.5.1",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-            "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.6.1.tgz",
+            "integrity": "sha512-gnk+lN50T7TIRp4bHTVydSnWsNkYAxGiDDbed3U26Z82s1lr8em4E4fLs/EPfIEZIbfi4Zfo5NsdA9gHWbPmXg==",
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.4",
@@ -779,35 +667,6 @@
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "node_modules/cacheable-lookup": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-            "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.6.0"
-            }
-        },
-        "node_modules/cacheable-request": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-            "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "clone-response": "^1.0.2",
-                "get-stream": "^5.1.0",
-                "http-cache-semantics": "^4.0.0",
-                "keyv": "^4.0.0",
-                "lowercase-keys": "^2.0.0",
-                "normalize-url": "^6.0.1",
-                "responselike": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/callsites": {
@@ -835,19 +694,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/clone-response": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-            "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-response": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/color-convert": {
@@ -941,97 +787,12 @@
                 }
             }
         },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/decompress-response/node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/defer-to-connect": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/define-properties": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "define-data-property": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/detect-node": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
@@ -1073,31 +834,31 @@
             }
         },
         "node_modules/electron": {
-            "version": "40.0.0",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-40.0.0.tgz",
-            "integrity": "sha512-UyBy5yJ0/wm4gNugCtNPjvddjAknMTuXR2aCHioXicH7aKRKGDBPp4xqTEi/doVcB3R+MN3wfU9o8d/9pwgK2A==",
+            "version": "42.3.0",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-42.3.0.tgz",
+            "integrity": "sha512-9ZiLdRXk+WDxW1OgIUz8J2rIQ5TYU9o629gCOjU48Q3dQiOmym7osWsH5Ubs/Jh4uuFLn6m6SBD2rmRXLAPz9g==",
             "dev": true,
-            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@electron/get": "^2.0.0",
+                "@electron/get": "^5.0.0",
                 "@types/node": "^24.9.0",
                 "extract-zip": "^2.0.1"
             },
             "bin": {
-                "electron": "cli.js"
+                "electron": "cli.js",
+                "install-electron": "install.js"
             },
             "engines": {
-                "node": ">= 12.20.55"
+                "node": ">= 22.12.0"
             }
         },
         "node_modules/electron-updater": {
-            "version": "6.7.3",
-            "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.7.3.tgz",
-            "integrity": "sha512-EgkT8Z9noqXKbwc3u5FkJA+r48jwZ5DTUiOkJMOTEEH//n5Am6wfQGz7nvSFEA2oIAMv9jRzn5JKTyWeSKOPgg==",
+            "version": "6.8.6",
+            "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.6.tgz",
+            "integrity": "sha512-taWDzUH44Ax0gi2Zx+107nCfLxky2UfVYnkMlcpcu7WBGrkY8GcSdJIYa3ACHe3L6kMfcXWBIT6tjY5kt/cVFg==",
             "license": "MIT",
             "dependencies": {
-                "builder-util-runtime": "9.5.1",
+                "builder-util-runtime": "9.6.1",
                 "fs-extra": "^10.1.0",
                 "js-yaml": "^4.1.0",
                 "lazy-val": "^1.0.5",
@@ -1121,10 +882,22 @@
                 "node": ">=12"
             }
         },
+        "node_modules/electron-updater/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/electron/node_modules/@types/node": {
-            "version": "24.10.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
-            "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+            "version": "24.12.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+            "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1149,20 +922,21 @@
             }
         },
         "node_modules/engine.io": {
-            "version": "6.6.5",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
-            "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
+            "version": "6.6.8",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
+            "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
             "license": "MIT",
             "dependencies": {
                 "@types/cors": "^2.8.12",
                 "@types/node": ">=10.0.0",
+                "@types/ws": "^8.5.12",
                 "accepts": "~1.3.4",
                 "base64id": "2.0.0",
                 "cookie": "~0.7.2",
                 "cors": "~2.8.5",
                 "debug": "~4.4.1",
                 "engine.io-parser": "~5.2.1",
-                "ws": "~8.18.3"
+                "ws": "~8.20.1"
             },
             "engines": {
                 "node": ">=10.2.0"
@@ -1178,13 +952,16 @@
             }
         },
         "node_modules/env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+            "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=6"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/err-code": {
@@ -1193,36 +970,6 @@
             "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es6-error": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -1325,9 +1072,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1336,9 +1083,9 @@
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1563,9 +1310,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -1612,7 +1359,7 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1644,9 +1391,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1655,9 +1402,9 @@
             }
         },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1665,25 +1412,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/global-agent": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-            "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "dependencies": {
-                "boolean": "^3.0.1",
-                "es6-error": "^4.1.1",
-                "matcher": "^3.0.0",
-                "roarr": "^2.15.3",
-                "semver": "^7.3.2",
-                "serialize-error": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=10.0"
             }
         },
         "node_modules/globals": {
@@ -1700,24 +1428,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globalthis": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "define-properties": "^1.2.1",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/globby": {
@@ -1741,46 +1451,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/got": {
-            "version": "11.8.6",
-            "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-            "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/is": "^4.0.0",
-                "@szmarczak/http-timer": "^4.0.5",
-                "@types/cacheable-request": "^6.0.1",
-                "@types/responselike": "^1.0.0",
-                "cacheable-lookup": "^5.0.3",
-                "cacheable-request": "^7.0.2",
-                "decompress-response": "^6.0.0",
-                "http2-wrapper": "^1.0.0-beta.5.2",
-                "lowercase-keys": "^2.0.0",
-                "p-cancelable": "^2.0.0",
-                "responselike": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.19.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/got?sponsor=1"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1802,41 +1472,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-            "dev": true,
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/http2-wrapper": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-            "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "quick-lru": "^5.1.1",
-                "resolve-alpn": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=10.19.0"
             }
         },
         "node_modules/ignore": {
@@ -2001,18 +1636,10 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-            "dev": true,
-            "license": "ISC",
-            "optional": true
-        },
         "node_modules/jsonfile": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
             "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
@@ -2068,9 +1695,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.escaperegexp": {
@@ -2098,30 +1725,6 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/lowercase-keys": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/matcher": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "escape-string-regexp": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -2168,24 +1771,14 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-response": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -2216,19 +1809,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/normalize-url": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2236,17 +1816,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/once": {
@@ -2275,16 +1844,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/p-cancelable": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-            "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/p-limit": {
@@ -2380,9 +1939,9 @@
             "license": "MIT"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2441,9 +2000,9 @@
             }
         },
         "node_modules/pump": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2491,26 +2050,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/quick-lru": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/resolve-alpn": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2519,19 +2058,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/responselike": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-            "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lowercase-keys": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/retry": {
@@ -2572,25 +2098,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/roarr": {
-            "version": "2.15.4",
-            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "dependencies": {
-                "boolean": "^3.0.1",
-                "detect-node": "^2.0.4",
-                "globalthis": "^1.0.1",
-                "json-stringify-safe": "^5.0.1",
-                "semver-compare": "^1.0.0",
-                "sprintf-js": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2616,63 +2123,25 @@
             }
         },
         "node_modules/sax": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-            "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=11.0.0"
             }
         },
         "node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/semver-compare": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/serialize-error": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "type-fest": "^0.13.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/serialize-error/node_modules/type-fest": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "optional": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/shebang-command": {
@@ -2727,19 +2196,19 @@
             }
         },
         "node_modules/socket.io-adapter": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
-            "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
+            "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
             "license": "MIT",
             "dependencies": {
                 "debug": "~4.4.1",
-                "ws": "~8.18.3"
+                "ws": "~8.20.1"
             }
         },
         "node_modules/socket.io-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
-            "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+            "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
             "license": "MIT",
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
@@ -2748,14 +2217,6 @@
             "engines": {
                 "node": ">=10.0.0"
             }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
@@ -2888,6 +2349,17 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/undici": {
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+            "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=20.18.1"
+            }
+        },
         "node_modules/undici-types": {
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -2956,9 +2428,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/ElectronSharp.Host/package.json
+++ b/ElectronSharp.Host/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "dasherize": "^2.0.0",
-        "electron-updater": "^6.3.0-alpha.4",
+        "electron-updater": "^6.8.6",
         "image-size": "^1.1.1",
         "portscanner": "^2.2.0",
         "socket.io": "^4.7.5"
@@ -24,7 +24,7 @@
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@typescript-eslint/parser": "^7.8.0",
         "dotenv": "^16.4.5",
-        "electron": "40.0.0",
+        "electron": "42.3.0",
         "eslint": "^8.57.0",
         "typescript": "^5.4.5"
     }


### PR DESCRIPTION
## Summary
This PR upgrades the pinned Electron version from 40.0.0 to 42.3.0 across the codebase, updates the `electron-updater` dependency, adds three new cookie change cause enums for Electron 41+, and introduces a `CLAUDE.md` file documenting the repository structure and conventions for AI-assisted development.

## Key Changes

- **Electron version bump**: Updated from 40.0.0 to 42.3.0 in:
  - `ElectronSharp.Host/package.json` (devDependencies)
  - `ElectronSharp.CLI/Commands/BuildCommand.cs` (_defaultElectronVersion constant)
  - `.devops/build-nuget.yaml` (PackageVersion variable)

- **Dependency updates**:
  - `electron-updater`: ^6.3.0-alpha.4 → ^6.8.6

- **New CookieChangedCause enum values** (Electron 41+ support):
  - `inserted`: Cookie was inserted (new cookie set)
  - `insertedNoChangeOverwrite`: Identical cookie set with no change
  - `insertedNoValueChangeOverwrite`: Only cookie attributes updated, value unchanged

- **Documentation**: Added `CLAUDE.md` with comprehensive guidance covering:
  - Project overview and repository links
  - Solution layout and project responsibilities
  - Electron version pinning locations and the `Releaser` tool
  - Host (Node.js) and CLI architecture
  - Build, test, and pack procedures
  - TFMs, conventions, and branch etiquette
  - Common gotchas and troubleshooting

- **Minor csproj cleanup**: Removed redundant `<PackageType>DotnetCliTool</PackageType>` from `ElectronSharp.CLI.csproj` (already implied by `<ToolCommandName>`).

## Implementation Notes

All three Electron version pinning locations have been updated in sync, as documented in `CLAUDE.md`. The `Releaser` tool is the canonical way to perform such updates in the future to prevent drift.

https://claude.ai/code/session_01Ju4MJqkRTYyft1e3TCZFxR